### PR TITLE
Switch to browser explicit wait

### DIFF
--- a/udemyscraper.py
+++ b/udemyscraper.py
@@ -8,6 +8,12 @@ from selenium import webdriver  # for webdriver
 # for suppressing the browser
 from selenium.webdriver.chrome.options import Options
 
+# to wait until page loads
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.common.by import By
+
 
 class UdemyCourse():
     with open('warning.txt') as file:
@@ -54,7 +60,15 @@ class UdemyCourse():
         browser = webdriver.Chrome(
             executable_path='chromedriver.exe', chrome_options=option)
         browser.get(url)
-        time.sleep(3)
+
+        # Wait until the search box loads
+        try:
+            element_present = EC.presence_of_element_located(
+                (By.CLASS_NAME, 'course-directory--container--5ZPhr'))
+            WebDriverWait(browser, 3).until(element_present)
+        except TimeoutException:
+            print("Timed out waiting for page to load")
+            exit()
 
         # Get page source
         content = browser.page_source
@@ -70,8 +84,14 @@ class UdemyCourse():
         url = self.link
         browser.get(url)
 
-        # Wait for the browser to completely load the page. You can change this depending on your internet speed.
-        time.sleep(4)
+        # Wait till the price div loads
+        try:
+            element_present = EC.presence_of_element_located(
+                (By.CLASS_NAME, 'price-text--container--103D9'))
+            WebDriverWait(browser, 4).until(element_present)
+        except TimeoutException:
+            print("Timed out waiting for page to load")
+            exit()
 
         # Get the html
         content = browser.page_source

--- a/udemyscraper.py
+++ b/udemyscraper.py
@@ -64,7 +64,7 @@ class UdemyCourse():
         # Wait until the search box loads
         try:
             element_present = EC.presence_of_element_located(
-                (By.CLASS_NAME, 'course-directory--container--5ZPhr'))
+                (By.XPATH, "//div[starts-with(@class, 'course-directory--container--')]"))
             WebDriverWait(browser, 3).until(element_present)
         except TimeoutException:
             print("Timed out waiting for page to load")


### PR DESCRIPTION
**EXPERIMENTAL! Needs Testing.**

`time.sleep()` introduces a necessary wait, even if the page has already been loaded.

By using `expected_components`, we can proceed as and when the element loads.
Using the python time library, I calculated the time taken by search and course page to load to be 2 seconds (approx.)

Theoretically speaking, after the change, execution time should have reduced by 5 seconds. (`3+4-2`)
However, the gain was only 3 seconds instead of the expected 5.

This behavior seems unexpected for the moment, unless we can find where the missing 2 seconds are.
For a reference, the original version, using `time.sleep()` took 17 seconds to execute.

(All times are measured for my internet connection, by executing the given example in readme file)

Possibly need to dig further. I haven't yet got the time to read full code.