### PR TITLE
Check platform to call chromedriver

### DIFF
--- a/udemyscraper.py
+++ b/udemyscraper.py
@@ -1,3 +1,4 @@
+import platform
 import time
 import json
 from bs4 import BeautifulSoup
@@ -51,8 +52,13 @@ class UdemyCourse():
         option = Options()
         option.add_argument('headless')
         option.add_experimental_option('excludeSwitches', ['enable-logging'])
-        browser = webdriver.Chrome(
-            executable_path='chromedriver.exe', chrome_options=option)
+
+        if platform.system() == "Windows":
+            browser = webdriver.Chrome(
+                executable_path='chromedriver.exe', chrome_options=option)
+        else:
+            browser = webdriver.Chrome(chrome_options=option)
+
         browser.get(url)
         time.sleep(3)
 


### PR DESCRIPTION
By using `platform.system()` we can determine the OS family. This way we can use different call options for webdriver.

Until now, non Windows users were required to edit the source to use the library.