### PR TITLE
Added Lesson Details

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![License](https://img.shields.io/badge/LICENSE-GPL--3.0-brightgreen?style=for-the-badge)
 ![Python](https://img.shields.io/badge/PYTHON-3.9.6-blue?style=for-the-badge&logo=python&logoColor=white)
 ![Chromium](https://img.shields.io/badge/CHROMIUM-92.0.3-GREEN?style=for-the-badge&logo=GoogleChrome&logoColor=white)
-![Udemyscraper](https://img.shields.io/badge/UDEMYSCRAPER-0.6.0-magenta?style=for-the-badge&logo=udemy&logoColor=white)
+![Udemyscraper](https://img.shields.io/badge/UDEMYSCRAPER-0.7.0-magenta?style=for-the-badge&logo=udemy&logoColor=white)
 
 
 A Web Scraper built with beautiful soup, that fetches udemy course information.

--- a/README.md
+++ b/README.md
@@ -212,15 +212,18 @@ This is the data of the parent class which is the course class itself.
 | Name            | Type    | Description                                           | Usage                              |
 |-----------------|---------|-------------------------------------------------------|------------------------------------|
 | `name`          | String  | Returns the name of the section of the course         | `course.Sections[4].name`          |
-| `duration`      | String  | The duration of the specific course                   | `course.Sections[4].duration`      |
+| `duration`      | String  | The duration of the specific section                  | `course.Sections[4].duration`      |
 | `Lessons`       | List    | List with all the lesson objects for the section      | `course.Sections[4].Lessons[2]`    |
 | `no_of_lessons` | Integer | Gives the number of lessons in the particular Section | `course.Sections[4].no_of_lessons` |
 
 ## Lesson Class
 
-| Name   | Type   | Description                  | Usage                                |
-|--------|--------|------------------------------|--------------------------------------|
-| `name` | String | Gives the name of the lesson | `course.Sections[4].Lessons[2].name` |
+| Name       | Type    | Description                                             | Usage                                    |
+|------------|---------|---------------------------------------------------------|------------------------------------------|
+| `name`     | String  | Gives the name of the lesson                            | `course.Sections[4].Lessons[2].name`     |
+| `demo`     | Boolean | Whether the lesson can be previewed or not              | `course.Sections[4].Lessons[2].demo`     |
+| `duration` | String  | The duration of the specific lesson                     | `course.Sections[4].Lessons[2].duration` |
+| `type`     | String  | Tells what type of lesson it is. (Video, Article, Quiz) | `course.Sections[4].Lessons[2].type`     |
 
 
 # Output/ Dumping data

--- a/texts/help.txt
+++ b/texts/help.txt
@@ -1,4 +1,4 @@
-udemyscraper 0.6.0 (cli)
+udemyscraper 0.7.0 (cli)
 Usage: udemyscraper.py [options] command
 
 udemyscraper is a free and open source tool beautiful soup, 

--- a/udemyscraper.py
+++ b/udemyscraper.py
@@ -22,6 +22,7 @@ __version__ = "0.6.0"
 
 
 def loginfo(message):
+    # Logs the message along with the time taken from the start
     logging.info(str(time.time()-__starttime__) + '  ' + message)
 
 
@@ -48,6 +49,11 @@ def display_warn():
 
 class Lesson():
     def __init__(self, lesson_html):
+
+        # Since the structure of previewable 
+        # lessons is different from that of the 
+        # ones that are not:
+
         if "Preview" in lesson_html.select_one("div").text:
             self.demo = True
             self.title = lesson_html.select_one(
@@ -57,6 +63,7 @@ class Lesson():
             self.title = lesson_html.select_one(
                 "span[class*='section--item-title--']").text
 
+        # Fetches the type of the lesson
         if "play" in str(lesson_html.select_one("use").attrs['xlink:href']):
             self.type = "Video"
             self.duration = lesson_html.select_one(
@@ -68,14 +75,9 @@ class Lesson():
             self.type = "article"
             self.duration = lesson_html.select_one(
                 "span[class*='section--hidden-on-mobile--171Q9 section--item-content-summary--']").text
-        else:
-            self.type = "error fetching type"
-            self.duration = "Nada :)"
 
 
 # Course class will contain an array with section classes
-
-
 class Section():
     def __init__(self, section_html):
         self.name = section_html.select_one(
@@ -94,7 +96,6 @@ class Section():
         self.no_of_lessons = len(self.Lessons)
         self.duration = section_html.select_one(
             "span[data-purpose='section-content']").text.split(" • ")[1].replace(" ", "")
-
 
 
 class UdemyCourse():

--- a/udemyscraper.py
+++ b/udemyscraper.py
@@ -43,6 +43,59 @@ def display_warn():
             print(line.replace("\n", ""))
             time.sleep(0.4)
 
+# Section class will contain an array with lesson classes
+
+
+class Lesson():
+    def __init__(self, lesson_html):
+        # self.name = lesson_html.select_one("span").text
+        # loginfo("Scraped Lesson HTML")
+
+        if "Preview" in lesson_html.select_one("div").text:
+            self.demo = True
+            self.title = lesson_html.select_one(
+                "button").text
+        else:
+            self.demo = False
+            self.title = lesson_html.select_one(
+                "span[class*='section--item-title--']").text
+
+        if "play" in str(lesson_html.select_one("use").attrs['xlink:href']):
+            self.type = "Video"
+            self.duration = lesson_html.select_one(
+                "span[class*='section--hidden-on-mobile--171Q9 section--item-content-summary--']").text
+        elif "quiz" in str(lesson_html.select_one("use").attrs['xlink:href']):
+            self.type = "quiz"
+            self.duration = None
+        elif "article" in str(lesson_html.select_one("use").attrs['xlink:href']) == "#icon-article":
+            self.type = "article"
+            self.duration = lesson_html.select_one(
+                "span[class*='section--hidden-on-mobile--171Q9 section--item-content-summary--']").text
+        else:
+            self.type = "error fetching type"
+            self.duration = "Nada :)"
+
+# Course class will contain an array with section classes
+
+
+class Section():
+    def __init__(self, section_html):
+        self.name = section_html.select_one(
+            "span[class*='section--section-title--']").text
+        loginfo("Scraped name")
+
+        self.duration = section_html.select_one(
+            "span[data-purpose='section-content']").text.split(' • ')[1].replace(' ', '')
+        loginfo('Scraped Section duration')
+
+        self.Lessons = []
+        for lesson in section_html.select("ul > li > div"):
+            self.Lessons.append(Lesson(lesson))
+            loginfo(
+                f"Lesson {len(self.Lessons)} scraped successfully")
+
+        self.no_of_lessons = len(self.Lessons)
+
 
 class UdemyCourse():
     def __init__(self, Preferences={
@@ -62,31 +115,6 @@ class UdemyCourse():
             logging.basicConfig(level=logging.INFO)
 
     def fetch_course(self, query):
-        # Course class will contain an array with section classes
-        class Section():
-            def __init__(self, section_html):
-                # Section class will contain an array with lesson classes
-                class Lesson():
-                    def __init__(self, lesson_html):
-                        self.name = lesson_html.select_one("span").text
-                        loginfo("Scraped Lesson HTML")
-
-                self.name = section_html.select_one(
-                    "span[class*='section--section-title--']").text
-                loginfo("Scraped name")
-
-                self.duration = section_html.select_one(
-                    "span[data-purpose='section-content']").text.split(' • ')[1].replace(' ', '')
-                loginfo('Scraped Section duration')
-
-                self.Lessons = []
-                for lesson in section_html.select("div[class='udlite-block-list-item-content']"):
-                    self.Lessons.append(Lesson(lesson))
-                    loginfo(
-                        f"Lesson {len(self.Lessons)} scraped successfully")
-
-                self.no_of_lessons = len(self.Lessons)
-
         # Get the url of the search query
         url = "https://www.udemy.com/courses/search/?src=ukw&q=" + query
 

--- a/udemyscraper.py
+++ b/udemyscraper.py
@@ -48,9 +48,6 @@ def display_warn():
 
 class Lesson():
     def __init__(self, lesson_html):
-        # self.name = lesson_html.select_one("span").text
-        # loginfo("Scraped Lesson HTML")
-
         if "Preview" in lesson_html.select_one("div").text:
             self.demo = True
             self.title = lesson_html.select_one(
@@ -75,6 +72,7 @@ class Lesson():
             self.type = "error fetching type"
             self.duration = "Nada :)"
 
+
 # Course class will contain an array with section classes
 
 
@@ -93,8 +91,10 @@ class Section():
             self.Lessons.append(Lesson(lesson))
             loginfo(
                 f"Lesson {len(self.Lessons)} scraped successfully")
-
         self.no_of_lessons = len(self.Lessons)
+        self.duration = section_html.select_one(
+            "span[data-purpose='section-content']").text.split(" • ")[1].replace(" ", "")
+
 
 
 class UdemyCourse():

--- a/udemyscraper.py
+++ b/udemyscraper.py
@@ -18,7 +18,7 @@ import getopt
 import sys
 from colorama import Fore, Style
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 
 
 def loginfo(message):


### PR DESCRIPTION
➕ Added Lesson Type and Duration

# Changes
- [x] Separated course and lesson classes instead of them being nested.
- [x] Scraper can now fetch the lesson type. That is if it's a video, quiz or an article.
- [x] with the `lesson.demo` property you can now find out whether it is previewable or not.
- [x] Can now fetch the lesson duration for videos and articles.
- [x] Renamed `lesson.name` to `lesson.title`
- [x] Get Section Duration
- [x] Comment Code
- [x] Document Changes in readme

# To do
~- [ ] Get the lesson discription~ Won't be implementing this as the description division requires a button to be clicked which will basically demolish the speed. It might take minutes to scrape a single course. Until I found a better way to do it, i won't be implementing this.
